### PR TITLE
Pass resource name to SelectionDialog

### DIFF
--- a/src/CustomizableDatagrid.js
+++ b/src/CustomizableDatagrid.js
@@ -115,6 +115,7 @@ class CustomizableDatagrid extends Component {
             columns={this.getColumnLabels()}
             onColumnClicked={this.toggleColumn}
             onClose={this.handleClose}
+            resource={rest.resource}
           />
         )}
         <Datagrid {...rest}>{React.Children.map(children, this.renderChild)}</Datagrid>


### PR DESCRIPTION
To allow label translations to work correctly, pass the resource name through to SelectionDialog