### PR TITLE
Add missing prop resource to SelectionDialog

### DIFF
--- a/src/CustomizableDatagrid.js
+++ b/src/CustomizableDatagrid.js
@@ -111,6 +111,7 @@ class CustomizableDatagrid extends Component {
         </div>
         {modalOpened && (
           <SelectionDialog
+            resource={resource}
             selection={selection}
             columns={this.getColumnLabels()}
             onColumnClicked={this.toggleColumn}


### PR DESCRIPTION
Fix #6 

FieldTitle handles i18n internally. It does so by, when field label is set, using it as key, and when only source is set, using key 'resources.${resource}.fields.${source}'. Currently, with undefined resource being passed to SelectionDialog, and so to FieldTitle, when no label is set, it uses key 'resources.undefined.fields.${source}'. Using that key on i18n files leads to correctly translated label with current version.
